### PR TITLE
Use `thiserror` instead of `failure`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 png = "0.16.0"
-failure = "0.1.7"
+thiserror = "1.0.25"
 byteorder = "1.3.4"
 flate2 = "1.0.14"
 image = "0.23.14"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,48 +1,24 @@
-use failure::Fail;
 use std::io::Error as IOError;
+use thiserror::Error as ThisError;
 
 pub type APNGResult<T> = Result<T, APNGError>;
 
-#[derive(Fail, Debug)]
+#[derive(ThisError, Debug)]
 pub enum APNGError {
-    #[fail(display = "IO error: {}", 0)]
-    Io(IOError),
-    #[fail(display = "images are not found")]
+    #[error("IO error: {0}")]
+    Io(#[from] IOError),
+    #[error("images are not found")]
     ImagesNotFound,
-    #[fail(display = "wrong data size, expected {} got {}", 0, 1)]
+    #[error("wrong data size, expected {0} got {1}")]
     WrongDataSize(usize, usize),
-    #[fail(display = "wrong frames nums, expected {} got {}", 0, 1)]
+    #[error("wrong frames nums, expected {0} got {1}")]
     WrongFrameNums(usize, usize),
 }
 
-macro_rules! define_error {
-    ($source:ty, $kind:tt) => {
-        impl From<$source> for APNGError {
-            fn from(error: $source) -> APNGError {
-                APNGError::$kind(error)
-            }
-        }
-    };
-}
-
-define_error!(std::io::Error, Io);
-
 pub type AppResult<T> = Result<T, AppError>;
 
-#[derive(Fail, Debug)]
+#[derive(ThisError, Debug)]
 pub enum AppError {
-    #[fail(display = "png decode error: {}", 0)]
+    #[error("png decode error: {0}")]
     PNGImage(png::DecodingError),
 }
-
-macro_rules! define_error {
-    ($source:ty, $kind:ident) => {
-        impl From<$source> for AppError {
-            fn from(error: $source) -> AppError {
-                AppError::$kind(error)
-            }
-        }
-    };
-}
-
-define_error!(png::DecodingError, PNGImage);


### PR DESCRIPTION
failure is deprecated: https://github.com/rust-lang-nursery/failure/pull/347
