### PR TITLE
Update dependencies and only include png support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 png = "0.17.7"
-thiserror = "1.0.29"
-byteorder = "1.3.4"
-flate2 = "1.0.22"
-image = "0.24.3"
+thiserror = "1.0.38"
+byteorder = "1.4.3"
+flate2 = "1.0.25"
+image = { version = "0.24.5", default-features = false, features = ["png"] }

--- a/examples/each_frame_speed/Cargo.toml
+++ b/examples/each_frame_speed/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 [dependencies]
 apng = { path = "../../" }
 png = "0.17.7"
-image = "0.24.3"
+image = { version = "0.24.5", default-features = false, features = ["png"] }

--- a/examples/encode_all/Cargo.toml
+++ b/examples/encode_all/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 [dependencies]
 apng = { path = "../../" }
 png = "0.17.7"
-image = "0.24.3"
+image = { version = "0.24.5", default-features = false, features = ["png"] }


### PR DESCRIPTION
Image crate includes every image format by default, but for this crate, it makes sense only to set the `png` feature. This makes the build run significantly faster.